### PR TITLE
feat(update-api-dep): update api dep to 0.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deps-cloud/gateway
 go 1.12
 
 require (
-	github.com/deps-cloud/api v0.1.0
+	github.com/deps-cloud/api v0.1.3
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.12.1
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deps-cloud/api v0.1.0 h1:V5NIn7IQICqMazmjmk5k4G68GdfEMz/lWVv2fknaCtM=
-github.com/deps-cloud/api v0.1.0/go.mod h1:+qCuS3PEg2lxQtQo9F/kObIIIn+ZtP4FSlU8n+QH4vQ=
+github.com/deps-cloud/api v0.1.3 h1:hh6X1YJNG768AzPAxRLYqH+PE5hHZJgdGdpP9DczELQ=
+github.com/deps-cloud/api v0.1.3/go.mod h1:+qCuS3PEg2lxQtQo9F/kObIIIn+ZtP4FSlU8n+QH4vQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
closes deps-cloud/deps.cloud#7

Updating the api dep version to let the new ref field come through in `dependencies` and `dependents` endpoint